### PR TITLE
fix: error on switch off all palettes

### DIFF
--- a/app/components/SquareGraph.tsx
+++ b/app/components/SquareGraph.tsx
@@ -46,7 +46,7 @@ export default function SquareGraph({
           {/* eslint-disable-next-line no-nested-ternary */}
           {palettes.length > 1
             ? `Lightness/Luminance`
-            : palettes[0].useLightness
+            : palettes[0]?.useLightness
             ? `Lightness`
             : `Luminance`}
         </div>


### PR DESCRIPTION
I encountered the error as shown below

https://user-images.githubusercontent.com/49279517/148087567-fa767117-79a4-48fd-ac06-1c20c8f13cec.mov

I just add optional chaining but it can be solve as:

```ts
{palettes.length > 1
  ? `Lightness/Luminance`
  : palettes[0]
  ? palettes[0].useLightness
    ? `Lightness`
    : `Luminance`
  : ''}
```
Not optimized but it works :)
