### PR TITLE
Replace numerical strings with numbers

### DIFF
--- a/app/components/Output.tsx
+++ b/app/components/Output.tsx
@@ -9,8 +9,8 @@ export default function Output({palettes}: {palettes: PaletteConfig[]}) {
   const [, copy] = useCopyToClipboard()
   const shaped = output(palettes)
 
-  const displayed = JSON.stringify({colors: shaped}, null, 2).replace(/"+[0-9]+"/g, function(match) {
-    return match.replace(/"/g,'');
+  const displayed = JSON.stringify({colors: shaped}, null, 2).replace(/"+[0-9]+"/g, function(m) {
+    return m.replace(/"/g,'');
   })
 
   return (

--- a/app/components/Output.tsx
+++ b/app/components/Output.tsx
@@ -9,7 +9,9 @@ export default function Output({palettes}: {palettes: PaletteConfig[]}) {
   const [, copy] = useCopyToClipboard()
   const shaped = output(palettes)
 
-  const displayed = JSON.stringify({colors: shaped}, null, 2)
+  const displayed = JSON.stringify({colors: shaped}, null, 2).replace(/"+[0-9]+"/g, function(match) {
+    return match.replace(/"/g,'');
+  })
 
   return (
     <section


### PR DESCRIPTION
Hi Simeon, this will replace quoted numerical strings with numbers to match tailwinds default config format.

## Before
```json
{
  "colors": {
    "red": {
      "50": "#FDECEC",
      "100": "#FCD9D9",
      "200": "#F9B4B4",
      "300": "#F58E8E",
      "400": "#F26969",
      "500": "#EF4444",
      "600": "#E11313",
      "700": "#A90F0F",
      "800": "#710A0A",
      "900": "#380505"
    }
  }
}
```

## After
```ts
{
  "colors": {
    "red": {
      50: "#FDECEC",
      100: "#FCD9D9",
      200: "#F9B4B4",
      300: "#F58E8E",
      400: "#F26969",
      500: "#EF4444",
      600: "#E11313",
      700: "#A90F0F",
      800: "#710A0A",
      900: "#380505"
    }
  }
}
```

Thank you for building this generator it's brilliant.