### PR TITLE
feat: allow '-' character in the palette name

### DIFF
--- a/app/components/Palette.tsx
+++ b/app/components/Palette.tsx
@@ -62,7 +62,7 @@ const paletteInputs: Record<string, PaletteInput> = {
     value: ``,
     min: 3,
     max: 24,
-    pattern: `[A-Za-z]{3,24}`,
+    pattern: `[A-Za-z\-]{3,24}`,
     classes: ``,
     transform: (value: string) => value,
   },

--- a/app/lib/helpers.ts
+++ b/app/lib/helpers.ts
@@ -162,7 +162,7 @@ export function isHex(value: string) {
 }
 
 export function isValidName(name: string) {
-  const re = new RegExp(/^[A-Za-z]{3,24}$/i);
+  const re = new RegExp(/^[A-Za-z\-]{3,24}$/i);
 
   return re.test(name);
 }


### PR DESCRIPTION
Hi there, is it possible to allow the '-' character as part of the palette name? 

![Screenshot 2025-06-10 at 18 23 59](https://github.com/user-attachments/assets/c4e153dd-f79e-4db7-892e-3174516c69e9)